### PR TITLE
fix(ui): adjust clear all button overlapping position 

### DIFF
--- a/ui/src/app/applications/components/filter/filter.scss
+++ b/ui/src/app/applications/components/filter/filter.scss
@@ -115,7 +115,6 @@ $slate: #191826;
     display: flex;
     flex-wrap: wrap;
     margin-top: 2em;
-    position: relative;
     
     &__toggle {
         display: none;
@@ -150,8 +149,7 @@ $slate: #191826;
         align-items: center;
         height: 1.5em;
         margin-bottom: 0em;
-        margin-top: -1.5em;
-        position: absolute;
+        margin-top: -3.5em;
 
         .argo-button {
             margin-left: auto;


### PR DESCRIPTION
Hi!

I was working on resolving some [filtering UI issues](https://github.com/argoproj/argo-cd/pull/23733) and came across a [similar problem](https://github.com/argoproj/argo-cd/issues/23553#issuecomment-3020181766). While investigating, I came across your comment and work on the topic and decided to take a closer look.

Based on your approach, I made some CSS modifications that I think complement your changes well. Could you please take a look at my adjustments? If It look good to you, I'd appreciate it if you could consider merging them into your PR.

Please let me know your thoughts!
<img width="227" height="492" alt="adjust_clear_all_filter" src="https://github.com/user-attachments/assets/91424902-55cc-40fe-a83c-2d776a69ba98" />

